### PR TITLE
Signal end of document

### DIFF
--- a/markup.js
+++ b/markup.js
@@ -53,3 +53,9 @@ module.exports.tableFooter = function () {
     type: 'table.footer'
   }
 }
+
+module.exports.documentEnd = function () {
+  return {
+    type: 'document.end'
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "abstract-document-builder",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "repository": "https://github.com/keis/abstract-document-builder",
   "license": "ISC",
   "files": [

--- a/test/unit/test.construct.js
+++ b/test/unit/test.construct.js
@@ -32,3 +32,10 @@ test('table row - nested', function (t) {
   var h1 = b._tableRow('aaa', l)
   t.deepEqual(h1, { type: 'table.row', values: ['aaa', l] })
 })
+
+test('document end', function (t) {
+  t.plan(1)
+  var b = new Builder(new Writable({objectMode: true}))
+  var documentEnd = b._documentEnd()
+  t.deepEqual(documentEnd, { type: 'document.end' })
+})


### PR DESCRIPTION
By adding a `documentEnd()` method, the caller can signal that a document has reached its end by making the following structure available:

```
{
  type: 'document.end'
}
```
